### PR TITLE
8099 range tombstone overlap bug

### DIFF
--- a/src/java/org/apache/cassandra/client/RingCache.java
+++ b/src/java/org/apache/cassandra/client/RingCache.java
@@ -29,7 +29,6 @@ import org.apache.cassandra.dht.Token;
 //import org.apache.cassandra.hadoop.ConfigHelper;
 import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.TokenRange;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/org/apache/cassandra/cql3/ColumnIdentifier.java
+++ b/src/java/org/apache/cassandra/cql3/ColumnIdentifier.java
@@ -42,7 +42,7 @@ import org.apache.cassandra.utils.memory.AbstractAllocator;
 public class ColumnIdentifier extends org.apache.cassandra.cql3.selection.Selectable implements IMeasurableMemory
 {
     public final ByteBuffer bytes;
-    private final String text;
+    public final String text;
 
     private static final long EMPTY_SIZE = ObjectSizes.measure(new ColumnIdentifier("", true));
 

--- a/src/java/org/apache/cassandra/db/ClusteringPrefix.java
+++ b/src/java/org/apache/cassandra/db/ClusteringPrefix.java
@@ -77,7 +77,24 @@ public interface ClusteringPrefix extends Aliasable<ClusteringPrefix>, IMeasurab
         {
             return this != Kind.EXCL_START_BOUND && this != Kind.EXCL_END_BOUND;
         }
+
+        public Kind invert()
+        {
+            switch (this)
+            {
+                case EXCL_START_BOUND: return EXCL_END_BOUND;
+                case EXCL_END_BOUND: return EXCL_START_BOUND;
+                case INCL_END_BOUND: return INCL_START_BOUND;
+                case INCL_START_BOUND: return INCL_END_BOUND;
+                case CLUSTERING: return CLUSTERING;
+                case STATIC_CLUSTERING: return STATIC_CLUSTERING;
+                default:
+                    throw new IllegalStateException("Missing entry for " + this);
+            }
+        }
     }
+
+
 
     public Kind kind();
 

--- a/src/java/org/apache/cassandra/db/RangeTombstoneList.java
+++ b/src/java/org/apache/cassandra/db/RangeTombstoneList.java
@@ -522,6 +522,9 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
         {
             assert i == 0 || comparator.compare(ends[i-1], start) <= 0;
 
+            if (i > 0 && !start.isStart())
+                start = start.invert();
+
             int c = comparator.compare(start, ends[i]);
             assert c <= 0;
             if (c == 0)
@@ -558,7 +561,7 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
                 // First deal with what might come before the newly added one.
                 if (comparator.compare(starts[i], start) < 0)
                 {
-                    addInternal(i, starts[i], start, markedAts[i], delTimes[i]);
+                    addInternal(i, starts[i], start.invert(), markedAts[i], delTimes[i]);
                     i++;
                     // We don't need to do the following line, but in spirit that's what we want to do
                     // setInternal(i, start, ends[i], markedAts, delTime])
@@ -609,7 +612,7 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
                     // one to reflect the not overwritten parts. We're then done.
                     addInternal(i, start, end, markedAt, delTime);
                     i++;
-                    setInternal(i, end, ends[i], markedAts[i], delTimes[i]);
+                    setInternal(i, end.invert(), ends[i], markedAts[i], delTimes[i]);
                     return;
                 }
             }
@@ -628,7 +631,7 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
                         addInternal(i, start, end, markedAt, delTime);
                         return;
                     }
-                    addInternal(i, start, starts[i], markedAt, delTime);
+                    addInternal(i, start, starts[i].invert(), markedAt, delTime);
                     i++;
                 }
 

--- a/src/java/org/apache/cassandra/db/RowUpdateBuilder.java
+++ b/src/java/org/apache/cassandra/db/RowUpdateBuilder.java
@@ -52,7 +52,7 @@ public class RowUpdateBuilder
 
     private final Row.Writer writer;
 
-    private RowUpdateBuilder(PartitionUpdate update, long timestamp, int ttl, Mutation mutation)
+    public RowUpdateBuilder(PartitionUpdate update, long timestamp, int ttl, Mutation mutation)
     {
         this.update = update;
 
@@ -150,6 +150,13 @@ public class RowUpdateBuilder
         ColumnDefinition def = getDefinition(columnName);
         assert def.type.isCollection() && def.type.isMultiCell();
         writer.writeComplexDeletion(def, new SimpleDeletionTime(defaultLiveness.timestamp() - 1, update.nowInSec()));
+        return this;
+    }
+
+    public RowUpdateBuilder addRangeTombstone(Slice slice)
+    {
+        update.addRangeTombstone(slice, deletionTime);
+
         return this;
     }
 

--- a/src/java/org/apache/cassandra/db/Slice.java
+++ b/src/java/org/apache/cassandra/db/Slice.java
@@ -351,6 +351,11 @@ public class Slice
             writer.writeBoundKind(kind());
         }
 
+        public Bound invert()
+        {
+            return withNewKind(kind().invert());
+        }
+
         // For use by intersects, it's called with the sstable bound opposite to the slice bound
         // (so if the slice bound is a start, it's call with the max sstable bound)
         private int compareTo(ClusteringComparator comparator, List<ByteBuffer> sstableBound)

--- a/src/java/org/apache/cassandra/db/Slice.java
+++ b/src/java/org/apache/cassandra/db/Slice.java
@@ -102,6 +102,17 @@ public class Slice
         return new Slice(Bound.inclusiveStartOf(values), Bound.inclusiveEndOf(values));
     }
 
+    public static Slice make(ClusteringComparator comparator, Clustering start, Clustering end)
+    {
+        // This doesn't give us what we want with the clustering prefix
+        assert start != Clustering.STATIC_CLUSTERING && end != Clustering.STATIC_CLUSTERING;
+
+        ByteBuffer[] startValues = extractValues(start);
+        ByteBuffer[] endValues = extractValues(end);
+
+        return new Slice(Bound.inclusiveStartOf(startValues), Bound.inclusiveEndOf(endValues));
+    }
+
     private static ByteBuffer[] extractValues(ClusteringPrefix clustering)
     {
         ByteBuffer[] values = new ByteBuffer[clustering.size()];

--- a/test/unit/org/apache/cassandra/SchemaLoader.java
+++ b/test/unit/org/apache/cassandra/SchemaLoader.java
@@ -422,9 +422,9 @@ public class SchemaLoader
                 .build();
 
         ByteBuffer cName = ByteBufferUtil.bytes("birthdate");
-        IndexType keys = withIdxType ? IndexType.KEYS : null;
-        return cfm.addOrReplaceColumnDefinition(ColumnDefinition.regularDef(cfm, cName, LongType.instance, null)
-                .setIndex(withIdxType ? ByteBufferUtil.bytesToHex(cName) : null, keys, null));
+        cfm.getColumnDefinition(cName).setIndex(withIdxType ? ByteBufferUtil.bytesToHex(cName) : null, IndexType.COMPOSITES, Collections.EMPTY_MAP);
+
+        return cfm;
     }
     public static CFMetaData compositeIndexCFMD(String ksName, String cfName, final Boolean withIdxType) throws ConfigurationException
     {
@@ -434,7 +434,7 @@ public class SchemaLoader
         ByteBuffer cName = ByteBufferUtil.bytes("col1");
         IndexType idxType = withIdxType ? IndexType.COMPOSITES : null;
         return cfm.addColumnDefinition(ColumnDefinition.regularDef(cfm, cName, UTF8Type.instance, 1)
-                                                       .setIndex(withIdxType ? "col1_idx" : null, idxType, Collections.<String, String>emptyMap()));
+                .setIndex(withIdxType ? "col1_idx" : null, idxType, Collections.<String, String>emptyMap()));
     }
     
     private static CFMetaData jdbcCFMD(String ksName, String cfName, AbstractType comp)

--- a/test/unit/org/apache/cassandra/SchemaLoader.java
+++ b/test/unit/org/apache/cassandra/SchemaLoader.java
@@ -415,12 +415,16 @@ public class SchemaLoader
     }
     public static CFMetaData indexCFMD(String ksName, String cfName, final Boolean withIdxType) throws ConfigurationException
     {
-        CFMetaData cfm = CFMetaData.Builder.create(ksName, cfName).addPartitionKey("key",AsciiType.instance).build();
+        CFMetaData cfm = CFMetaData.Builder.create(ksName, cfName)
+                .addPartitionKey("key", AsciiType.instance)
+                .addClusteringColumn("cols", AsciiType.instance)
+                .addRegularColumn("birthdate", LongType.instance)
+                .build();
 
         ByteBuffer cName = ByteBufferUtil.bytes("birthdate");
         IndexType keys = withIdxType ? IndexType.KEYS : null;
-        return cfm.addColumnDefinition(ColumnDefinition.regularDef(cfm, cName, LongType.instance, null)
-                                                       .setIndex(withIdxType ? ByteBufferUtil.bytesToHex(cName) : null, keys, null));
+        return cfm.addOrReplaceColumnDefinition(ColumnDefinition.regularDef(cfm, cName, LongType.instance, null)
+                .setIndex(withIdxType ? ByteBufferUtil.bytesToHex(cName) : null, keys, null));
     }
     public static CFMetaData compositeIndexCFMD(String ksName, String cfName, final Boolean withIdxType) throws ConfigurationException
     {

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -94,24 +94,6 @@ public class Util
         return row.getCell(cdef);
     }
 
-    public static ColumnDefinition getColumnDef(CFMetaData cfm, String name)
-    {
-
-        ByteBuffer bb = ByteBufferUtil.bytes(name);
-
-        //No comparator
-        if (cfm.comparator.size() == 0)
-            return cfm.getColumnDefinition(bb);
-
-        for (ColumnDefinition cdef : cfm.allColumns())
-        {
-            if (name.equals(cdef.name.text))
-                return cdef;
-        }
-
-        return null;
-    }
-
     /*
     public static CellName cellname(String... strs)
     {
@@ -200,7 +182,8 @@ public class Util
         if (superColumn != null)
             filter.add(cfs.metadata.compactValueColumn(), Operator.EQ, superColumn);
 
-        ReadCommand command =  new PartitionRangeReadCommand(cfs.metadata, FBUtilities.nowInSeconds(), filter, DataLimits.cqlLimits(100000), DataRange.allData(cfs.metadata, cfs.partitioner));
+
+        ReadCommand command = new PartitionRangeReadCommand(cfs.metadata, FBUtilities.nowInSeconds() +1 , filter, DataLimits.cqlLimits(100000), DataRange.allData(cfs.metadata, cfs.partitioner));
 
         return command.executeLocally(cfs);
     }

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Future;
 
 import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.config.ColumnDefinition;
+import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.atoms.*;
@@ -86,6 +87,30 @@ public class Util
     }
 
 
+    public static Cell getRegularCell(CFMetaData metadata, Row row, String name)
+    {
+        ColumnDefinition cdef = new ColumnDefinition(metadata.ksName, metadata.cfName, new ColumnIdentifier(name, true), metadata.columnNameComparator, null, ColumnDefinition.Kind.REGULAR);
+
+        return row.getCell(cdef);
+    }
+
+    public static ColumnDefinition getColumnDef(CFMetaData cfm, String name)
+    {
+
+        ByteBuffer bb = ByteBufferUtil.bytes(name);
+
+        //No comparator
+        if (cfm.comparator.size() == 0)
+            return cfm.getColumnDefinition(bb);
+
+        for (ColumnDefinition cdef : cfm.allColumns())
+        {
+            if (name.equals(cdef.name.text))
+                return cdef;
+        }
+
+        return null;
+    }
 
     /*
     public static CellName cellname(String... strs)

--- a/test/unit/org/apache/cassandra/cql3/RangeDeletionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/RangeDeletionTest.java
@@ -30,6 +30,6 @@ public class RangeDeletionTest extends CQLTester
         flush();
         execute("DELETE FROM %s WHERE a=? AND b=?", 1, 1);
         flush();
-        assertEmpty(execute("SELECT * FROM %s WHERE a=? AND b=? AND c=?", 1, 1, 1));
+        assertEmpty(execute("SELECT * FROM %s"));
     }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableUtils.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableUtils.java
@@ -1,0 +1,236 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.cassandra.io.sstable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.DeletionInfo;
+import org.apache.cassandra.db.atoms.AtomIterator;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.SSTableWriter;
+import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+
+public class SSTableUtils
+{
+    // first configured keyspace and cf
+    public static String KEYSPACENAME = "Keyspace1";
+    public static String CFNAME = "Standard1";
+
+    public SSTableUtils(String ksname, String cfname)
+    {
+        KEYSPACENAME = ksname;
+        CFNAME = cfname;
+    }
+
+    /**/
+   /* public static ColumnFamily createCF(long mfda, int ldt, Cell... cols)
+    {
+        return createCF(KEYSPACENAME, CFNAME, mfda, ldt, cols);
+    }
+
+    public static ColumnFamily createCF(String ksname, String cfname, long mfda, int ldt, Cell... cols)
+    {
+        ColumnFamily cf = ArrayBackedSortedColumns.factory.create(ksname, cfname);
+        cf.delete(new DeletionInfo(mfda, ldt));
+        for (Cell col : cols)
+            cf.addColumn(col);
+        return cf;
+    }
+
+    public static File tempSSTableFile(String keyspaceName, String cfname) throws IOException
+    {
+        return tempSSTableFile(keyspaceName, cfname, 0);
+    }
+
+    public static File tempSSTableFile(String keyspaceName, String cfname, int generation) throws IOException
+    {
+        File tempdir = File.createTempFile(keyspaceName, cfname);
+        if(!tempdir.delete() || !tempdir.mkdir())
+            throw new IOException("Temporary directory creation failed.");
+        tempdir.deleteOnExit();
+        File cfDir = new File(tempdir, keyspaceName + File.separator + cfname);
+        cfDir.mkdirs();
+        cfDir.deleteOnExit();
+        File datafile = new File(new Descriptor(cfDir, keyspaceName, cfname, generation, Descriptor.Type.FINAL).filenameFor("Data.db"));
+        if (!datafile.createNewFile())
+            throw new IOException("unable to create file " + datafile);
+        datafile.deleteOnExit();
+        return datafile;
+    }
+
+    public static void assertContentEquals(SSTableReader lhs, SSTableReader rhs)
+    {
+        ISSTableScanner slhs = lhs.getScanner(FBUtilities.nowInSeconds());
+        ISSTableScanner srhs = rhs.getScanner(FBUtilities.nowInSeconds());
+        while (slhs.hasNext())
+        {
+            AtomIterator ilhs = slhs.next();
+            assert srhs.hasNext() : "LHS contained more rows than RHS";
+            AtomIterator irhs = srhs.next();
+            assertContentEquals(ilhs, irhs);
+        }
+        assert !srhs.hasNext() : "RHS contained more rows than LHS";
+    }
+
+    public static void assertContentEquals(AtomIterator lhs, AtomIterator rhs)
+    {
+        assertEquals(lhs.getKey(), rhs.getKey());
+        // check metadata
+        ColumnFamily lcf = lhs.getColumnFamily();
+        ColumnFamily rcf = rhs.getColumnFamily();
+        if (lcf == null)
+        {
+            if (rcf == null)
+                return;
+            throw new AssertionError("LHS had no content for " + rhs.getKey());
+        }
+        else if (rcf == null)
+            throw new AssertionError("RHS had no content for " + lhs.getKey());
+        assertEquals(lcf.deletionInfo(), rcf.deletionInfo());
+        // iterate columns
+        while (lhs.hasNext())
+        {
+            Cell clhs = (Cell)lhs.next();
+            assert rhs.hasNext() : "LHS contained more columns than RHS for " + lhs.getKey();
+            Cell crhs = (Cell)rhs.next();
+
+            assertEquals("Mismatched columns for " + lhs.getKey(), clhs, crhs);
+        }
+        assert !rhs.hasNext() : "RHS contained more columns than LHS for " + lhs.getKey();
+    } */
+
+    /**
+     * @return A Context with chainable methods to configure and write a SSTable.
+     */
+    /*public static Context prepare()
+    {
+        return new Context();
+    }
+
+    public static class Context
+    {
+        private String ksname = KEYSPACENAME;
+        private String cfname = CFNAME;
+        private Descriptor dest = null;
+        private boolean cleanup = true;
+        private int generation = 0;
+
+        Context() {}
+
+        public Context ks(String ksname)
+        {
+            this.ksname = ksname;
+            return this;
+        }
+
+        public Context cf(String cfname)
+        {
+            this.cfname = cfname;
+            return this;
+        }
+
+
+         //Set an alternate path for the written SSTable: if unset, the SSTable will
+         //be cleaned up on JVM exit.
+         //
+        public Context dest(Descriptor dest)
+        {
+            this.dest = dest;
+            this.cleanup = false;
+            return this;
+        }
+
+        //
+        // Sets the generation number for the generated SSTable. Ignored if "dest()" is set.
+        //
+        public Context generation(int generation)
+        {
+            this.generation = generation;
+            return this;
+        }
+
+        public SSTableReader write(Set<String> keys) throws IOException
+        {
+            Map<String, ColumnFamily> map = new HashMap<String, ColumnFamily>();
+            for (String key : keys)
+            {
+                ColumnFamily cf = ArrayBackedSortedColumns.factory.create(ksname, cfname);
+                cf.addColumn(new BufferCell(Util.cellname(key), ByteBufferUtil.bytes(key), 0));
+                map.put(key, cf);
+            }
+            return write(map);
+        }
+
+        public SSTableReader write(SortedMap<DecoratedKey, ColumnFamily> sorted) throws IOException
+        {
+            final Iterator<Map.Entry<DecoratedKey, ColumnFamily>> iter = sorted.entrySet().iterator();
+            return write(sorted.size(), new Appender()
+            {
+                @Override
+                public boolean append(SSTableWriter writer) throws IOException
+                {
+                    if (!iter.hasNext())
+                        return false;
+                    Map.Entry<DecoratedKey, ColumnFamily> entry = iter.next();
+                    writer.append(entry.getKey(), entry.getValue());
+                    return true;
+                }
+            });
+        }
+
+        public SSTableReader write(Map<String, ColumnFamily> entries) throws IOException
+        {
+            SortedMap<DecoratedKey, ColumnFamily> sorted = new TreeMap<DecoratedKey, ColumnFamily>();
+            for (Map.Entry<String, ColumnFamily> entry : entries.entrySet())
+                sorted.put(Util.dk(entry.getKey()), entry.getValue());
+
+            return write(sorted);
+        }
+
+        public SSTableReader write(int expectedSize, Appender appender) throws IOException
+        {
+            File datafile = (dest == null) ? tempSSTableFile(ksname, cfname, generation) : new File(dest.filenameFor(Component.DATA));
+            SSTableWriter writer = SSTableWriter.create(Descriptor.fromFilename(datafile.getAbsolutePath()), expectedSize, ActiveRepairService.UNREPAIRED_SSTABLE, 0);
+            while (appender.append(writer))
+            {
+              // pass
+            }
+            SSTableReader reader = writer.closeAndOpenReader();
+            // mark all components for removal
+            if (cleanup)
+                for (Component component : reader.components)
+                    new File(reader.descriptor.filenameFor(component)).deleteOnExit();
+            return reader;
+        }
+    }
+
+    public static abstract class Appender
+    {
+        // Called with an open writer until it returns false.
+        public abstract boolean append(SSTableWriter writer) throws IOException;
+    }
+    */
+}

--- a/test/unit/org/apache/cassandra/io/util/BufferedRandomAccessFileTest.java
+++ b/test/unit/org/apache/cassandra/io/util/BufferedRandomAccessFileTest.java
@@ -1,0 +1,691 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.cassandra.io.util;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import org.apache.cassandra.service.FileCacheService;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import static org.apache.cassandra.Util.expectEOF;
+import static org.apache.cassandra.Util.expectException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BufferedRandomAccessFileTest
+{
+    @Test
+    public void testReadAndWrite() throws Exception
+    {
+        SequentialWriter w = createTempFile("braf");
+
+        // writting string of data to the file
+        byte[] data = "Hello".getBytes();
+        w.write(data);
+        assertEquals(data.length, w.length());
+        assertEquals(data.length, w.getFilePointer());
+
+        w.sync();
+
+        // reading small amount of data from file, this is handled by initial buffer
+        RandomAccessReader r = RandomAccessReader.open(w);
+
+        byte[] buffer = new byte[data.length];
+        assertEquals(data.length, r.read(buffer));
+        assertTrue(Arrays.equals(buffer, data)); // we read exactly what we wrote
+        assertEquals(r.read(), -1); // nothing more to read EOF
+        assert r.bytesRemaining() == 0 && r.isEOF();
+
+        r.close();
+
+        // writing buffer bigger than page size, which will trigger reBuffer()
+        byte[] bigData = new byte[RandomAccessReader.DEFAULT_BUFFER_SIZE + 10];
+
+        for (int i = 0; i < bigData.length; i++)
+            bigData[i] = 'd';
+
+        long initialPosition = w.getFilePointer();
+        w.write(bigData); // writing data
+        assertEquals(w.getFilePointer(), initialPosition + bigData.length);
+        assertEquals(w.length(), initialPosition + bigData.length); // file size should equals to last position
+
+        w.sync();
+
+        r = RandomAccessReader.open(w); // re-opening file in read-only mode
+
+        // reading written buffer
+        r.seek(initialPosition); // back to initial (before write) position
+        data = new byte[bigData.length];
+        long sizeRead = 0;
+        for (int i = 0; i < data.length; i++)
+        {
+            data[i] = (byte) r.read();
+            sizeRead++;
+        }
+
+        assertEquals(sizeRead, data.length); // read exactly data.length bytes
+        assertEquals(r.getFilePointer(), initialPosition + data.length);
+        assertEquals(r.length(), initialPosition + bigData.length);
+        assertTrue(Arrays.equals(bigData, data));
+        assertTrue(r.bytesRemaining() == 0 && r.isEOF()); // we are at the of the file
+
+        // test readBytes(int) method
+        r.seek(0);
+        ByteBuffer fileContent = r.readBytes((int) w.length());
+        assertEquals(fileContent.limit(), w.length());
+        assert ByteBufferUtil.string(fileContent).equals("Hello" + new String(bigData));
+
+        // read the same buffer but using readFully(int)
+        data = new byte[bigData.length];
+        r.seek(initialPosition);
+        r.readFully(data);
+        assert r.bytesRemaining() == 0 && r.isEOF(); // we should be at EOF
+        assertTrue(Arrays.equals(bigData, data));
+
+        // try to read past mark (all methods should return -1)
+        data = new byte[10];
+        assertEquals(r.read(), -1);
+        assertEquals(r.read(data), -1);
+        assertEquals(r.read(data, 0, data.length), -1);
+
+        // test read(byte[], int, int)
+        r.seek(0);
+        data = new byte[20];
+        assertEquals(15, r.read(data, 0, 15));
+        assertTrue(new String(data).contains("Hellodddddddddd"));
+        for (int i = 16; i < data.length; i++)
+        {
+            assert data[i] == 0;
+        }
+
+        w.close();
+        r.close();
+    }
+
+    @Test
+    public void testReadAndWriteOnCapacity() throws IOException
+    {
+        File tmpFile = File.createTempFile("readtest", "bin");
+        SequentialWriter w = SequentialWriter.open(tmpFile);
+
+        // Fully write the file and sync..
+        byte[] in = generateByteArray(RandomAccessReader.DEFAULT_BUFFER_SIZE);
+        w.write(in);
+
+        RandomAccessReader r = RandomAccessReader.open(w);
+
+        // Read it into a same size array.
+        byte[] out = new byte[RandomAccessReader.DEFAULT_BUFFER_SIZE];
+        r.read(out);
+
+        // Cannot read any more.
+        int negone = r.read();
+        assert negone == -1 : "We read past the end of the file, should have gotten EOF -1. Instead, " + negone;
+
+        r.close();
+        w.close();
+    }
+
+    @Test
+    public void testLength() throws IOException
+    {
+        File tmpFile = File.createTempFile("lengthtest", "bin");
+        SequentialWriter w = SequentialWriter.open(tmpFile);
+        assertEquals(0, w.length());
+
+        // write a chunk smaller then our buffer, so will not be flushed
+        // to disk
+        byte[] lessThenBuffer = generateByteArray(RandomAccessReader.DEFAULT_BUFFER_SIZE / 2);
+        w.write(lessThenBuffer);
+        assertEquals(lessThenBuffer.length, w.length());
+
+        // sync the data and check length
+        w.sync();
+        assertEquals(lessThenBuffer.length, w.length());
+
+        // write more then the buffer can hold and check length
+        byte[] biggerThenBuffer = generateByteArray(RandomAccessReader.DEFAULT_BUFFER_SIZE * 2);
+        w.write(biggerThenBuffer);
+        assertEquals(biggerThenBuffer.length + lessThenBuffer.length, w.length());
+
+        w.close();
+
+        // will use cachedlength
+        RandomAccessReader r = RandomAccessReader.open(tmpFile);
+        assertEquals(lessThenBuffer.length + biggerThenBuffer.length, r.length());
+        r.close();
+    }
+
+    @Test
+    public void testReadBytes() throws IOException
+    {
+        final SequentialWriter w = createTempFile("brafReadBytes");
+
+        byte[] data = new byte[RandomAccessReader.DEFAULT_BUFFER_SIZE + 10];
+
+        for (int i = 0; i < data.length; i++)
+        {
+            data[i] = 'c';
+        }
+
+        w.write(data);
+        w.sync();
+
+        final RandomAccessReader r = RandomAccessReader.open(w);
+
+        ByteBuffer content = r.readBytes((int) r.length());
+
+        // after reading whole file we should be at EOF
+        assertEquals(0, ByteBufferUtil.compare(content, data));
+        assert r.bytesRemaining() == 0 && r.isEOF();
+
+        r.seek(0);
+        content = r.readBytes(10); // reading first 10 bytes
+        assertEquals(ByteBufferUtil.compare(content, "cccccccccc".getBytes()), 0);
+        assertEquals(r.bytesRemaining(), r.length() - content.limit());
+
+        // trying to read more than file has right now
+        expectEOF(new Callable<Object>()
+        {
+            public Object call() throws IOException
+            {
+                return r.readBytes((int) r.length() + 10);
+            }
+        });
+
+        w.close();
+        r.close();
+    }
+
+    @Test
+    public void testSeek() throws Exception
+    {
+        SequentialWriter w = createTempFile("brafSeek");
+        byte[] data = generateByteArray(RandomAccessReader.DEFAULT_BUFFER_SIZE + 20);
+        w.write(data);
+        w.close();
+
+        final RandomAccessReader file = RandomAccessReader.open(w);
+
+        file.seek(0);
+        assertEquals(file.getFilePointer(), 0);
+        assertEquals(file.bytesRemaining(), file.length());
+
+        file.seek(20);
+        assertEquals(file.getFilePointer(), 20);
+        assertEquals(file.bytesRemaining(), file.length() - 20);
+
+        // trying to seek past the end of the file should produce EOFException
+        expectException(new Callable<Object>()
+        {
+            public Object call()
+            {
+                file.seek(file.length() + 30);
+                return null;
+            }
+        }, IllegalArgumentException.class);
+
+        expectException(new Callable<Object>()
+        {
+            public Object call() throws IOException
+            {
+                file.seek(-1);
+                return null;
+            }
+        }, IllegalArgumentException.class); // throws IllegalArgumentException
+
+        file.close();
+    }
+
+    @Test
+    public void testSkipBytes() throws IOException
+    {
+        SequentialWriter w = createTempFile("brafSkipBytes");
+        w.write(generateByteArray(RandomAccessReader.DEFAULT_BUFFER_SIZE * 2));
+        w.close();
+
+        RandomAccessReader file = RandomAccessReader.open(w);
+
+        file.seek(0); // back to the beginning of the file
+        assertEquals(file.skipBytes(10), 10);
+        assertEquals(file.bytesRemaining(), file.length() - 10);
+
+        int initialPosition = (int) file.getFilePointer();
+        // can't skip more than file size
+        assertEquals(file.skipBytes((int) file.length() + 10), file.length() - initialPosition);
+        assertEquals(file.getFilePointer(), file.length());
+        assert file.bytesRemaining() == 0 && file.isEOF();
+
+        file.seek(0);
+
+        // skipping negative amount should return 0
+        assertEquals(file.skipBytes(-1000), 0);
+        assertEquals(file.getFilePointer(), 0);
+        assertEquals(file.bytesRemaining(), file.length());
+
+        file.close();
+    }
+
+    @Test
+    public void testGetFilePointer() throws IOException
+    {
+        final SequentialWriter w = createTempFile("brafGetFilePointer");
+
+        assertEquals(w.getFilePointer(), 0); // initial position should be 0
+
+        w.write(generateByteArray(20));
+        assertEquals(w.getFilePointer(), 20); // position 20 after writing 20 bytes
+
+        w.sync();
+
+        RandomAccessReader r = RandomAccessReader.open(w);
+
+        // position should change after skip bytes
+        r.seek(0);
+        r.skipBytes(15);
+        assertEquals(r.getFilePointer(), 15);
+
+        r.read();
+        assertEquals(r.getFilePointer(), 16);
+        r.read(new byte[4]);
+        assertEquals(r.getFilePointer(), 20);
+
+        w.close();
+        r.close();
+    }
+
+    @Test
+    public void testGetPath() throws IOException
+    {
+        SequentialWriter file = createTempFile("brafGetPath");
+        assert file.getPath().contains("brafGetPath");
+        file.close();
+    }
+
+    @Test
+    public void testIsEOF() throws IOException
+    {
+        for (int bufferSize : Arrays.asList(1, 2, 3, 5, 8, 64))  // smaller, equal, bigger buffer sizes
+        {
+            final byte[] target = new byte[32];
+
+            // single too-large read
+            for (final int offset : Arrays.asList(0, 8))
+            {
+                File file1 = writeTemporaryFile(new byte[16]);
+                try (final RandomAccessReader file = RandomAccessReader.open(file1, bufferSize, null))
+                {
+                    expectEOF(new Callable<Object>()
+                    {
+                        public Object call() throws IOException
+                        {
+                            file.readFully(target, offset, 17);
+                            return null;
+                        }
+                    });
+                }
+            }
+
+            // first read is ok but eventually EOFs
+            for (final int n : Arrays.asList(1, 2, 4, 8))
+            {
+                File file1 = writeTemporaryFile(new byte[16]);
+                try (final RandomAccessReader file = RandomAccessReader.open(file1, bufferSize, null))
+                {
+                    expectEOF(new Callable<Object>()
+                    {
+                        public Object call() throws IOException
+                        {
+                            while (true)
+                                file.readFully(target, 0, n);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testNotEOF() throws IOException
+    {
+        assertEquals(1, RandomAccessReader.open(writeTemporaryFile(new byte[1])).read(new byte[2]));
+    }
+
+    @Test
+    public void testBytesRemaining() throws IOException
+    {
+        SequentialWriter w = createTempFile("brafBytesRemaining");
+
+        int toWrite = RandomAccessReader.DEFAULT_BUFFER_SIZE + 10;
+
+        w.write(generateByteArray(toWrite));
+
+        w.sync();
+
+        RandomAccessReader r = RandomAccessReader.open(w);
+
+        assertEquals(r.bytesRemaining(), toWrite);
+
+        for (int i = 1; i <= r.length(); i++)
+        {
+            r.read();
+            assertEquals(r.bytesRemaining(), r.length() - i);
+        }
+
+        r.seek(0);
+        r.skipBytes(10);
+        assertEquals(r.bytesRemaining(), r.length() - 10);
+
+        w.close();
+        r.close();
+    }
+
+    @Test
+    public void testBytesPastMark() throws IOException
+    {
+        File tmpFile = File.createTempFile("overflowtest", "bin");
+        tmpFile.deleteOnExit();
+
+        // Create the BRAF by filename instead of by file.
+        try (final RandomAccessReader r = RandomAccessReader.open(new File(tmpFile.getPath())))
+        {
+            assert tmpFile.getPath().equals(r.getPath());
+    
+            // Create a mark and move the rw there.
+            final FileMark mark = r.mark();
+            r.reset(mark);
+    
+            // Expect this call to succeed.
+            r.bytesPastMark(mark);
+        }
+    }
+
+    @Test
+    public void testClose() throws IOException
+    {
+        final SequentialWriter w = createTempFile("brafClose");
+
+        byte[] data = generateByteArray(RandomAccessReader.DEFAULT_BUFFER_SIZE + 20);
+
+        w.write(data);
+        w.close(); // will flush
+
+        final RandomAccessReader r = RandomAccessReader.open(new File(w.getPath()));
+
+        r.close(); // closing to test read after close
+
+        expectException(new Callable<Object>()
+        {
+            public Object call()
+            {
+                return r.read();
+            }
+        }, AssertionError.class);
+
+        expectException(new Callable<Object>()
+        {
+            public Object call() throws IOException
+            {
+                w.write(generateByteArray(1));
+                return null;
+            }
+        }, ClosedChannelException.class);
+
+        try (RandomAccessReader copy = RandomAccessReader.open(new File(r.getPath())))
+        {
+            ByteBuffer contents = copy.readBytes((int) copy.length());
+    
+            assertEquals(contents.limit(), data.length);
+            assertEquals(ByteBufferUtil.compare(contents, data), 0);
+        }
+    }
+
+    @Test
+    public void testMarkAndReset() throws IOException
+    {
+        SequentialWriter w = createTempFile("brafTestMark");
+        w.write(new byte[30]);
+
+        w.close();
+
+        RandomAccessReader file = RandomAccessReader.open(w);
+
+        file.seek(10);
+        FileMark mark = file.mark();
+
+        file.seek(file.length());
+        assertTrue(file.isEOF());
+
+        file.reset();
+        assertEquals(file.bytesRemaining(), 20);
+
+        file.seek(file.length());
+        assertTrue(file.isEOF());
+
+        file.reset(mark);
+        assertEquals(file.bytesRemaining(), 20);
+
+        file.seek(file.length());
+        assertEquals(file.bytesPastMark(), 20);
+        assertEquals(file.bytesPastMark(mark), 20);
+
+        file.reset(mark);
+        assertEquals(file.bytesPastMark(), 0);
+
+        file.close();
+    }
+
+    @Test (expected = AssertionError.class)
+    public void testAssertionErrorWhenBytesPastMarkIsNegative() throws IOException
+    {
+        try (SequentialWriter w = createTempFile("brafAssertionErrorWhenBytesPastMarkIsNegative"))
+        {
+            w.write(new byte[30]);
+            w.flush();
+    
+            try (RandomAccessReader r = RandomAccessReader.open(w))
+            {
+                r.seek(10);
+                r.mark();
+        
+                r.seek(0);
+                r.bytesPastMark();
+            }
+        }
+    }
+
+    @Test
+    public void testFileCacheService() throws IOException, InterruptedException
+    {
+        //see https://issues.apache.org/jira/browse/CASSANDRA-7756
+
+        final FileCacheService.CacheKey cacheKey = new FileCacheService.CacheKey();
+        final int THREAD_COUNT = 40;
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+
+        SequentialWriter w1 = createTempFile("fscache1");
+        SequentialWriter w2 = createTempFile("fscache2");
+
+        w1.write(new byte[30]);
+        w1.close();
+
+        w2.write(new byte[30]);
+        w2.close();
+
+        for (int i = 0; i < 20; i++)
+        {
+
+
+            RandomAccessReader r1 = RandomAccessReader.open(w1);
+            RandomAccessReader r2 = RandomAccessReader.open(w2);
+
+
+            FileCacheService.instance.put(cacheKey, r1);
+            FileCacheService.instance.put(cacheKey, r2);
+
+            final CountDownLatch finished = new CountDownLatch(THREAD_COUNT);
+            final AtomicBoolean hadError = new AtomicBoolean(false);
+
+            for (int k = 0; k < THREAD_COUNT; k++)
+            {
+                executorService.execute( new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        try
+                        {
+                            long size = FileCacheService.instance.sizeInBytes();
+
+                            while (size > 0)
+                                size = FileCacheService.instance.sizeInBytes();
+                        }
+                        catch (Throwable t)
+                        {
+                            t.printStackTrace();
+                            hadError.set(true);
+                        }
+                        finally
+                        {
+                            finished.countDown();
+                        }
+                    }
+                });
+
+            }
+
+            finished.await();
+            assert !hadError.get();
+        }
+    }
+
+    @Test
+    public void testReadOnly() throws IOException
+    {
+        SequentialWriter file = createTempFile("brafReadOnlyTest");
+
+        byte[] data = new byte[20];
+        for (int i = 0; i < data.length; i++)
+            data[i] = 'c';
+
+        file.write(data);
+        file.sync(); // flushing file to the disk
+
+        // read-only copy of the file, with fixed file length
+        final RandomAccessReader copy = RandomAccessReader.open(new File(file.getPath()));
+
+        copy.seek(copy.length());
+        assertTrue(copy.bytesRemaining() == 0 && copy.isEOF());
+
+        // can't seek past the end of the file for read-only files
+        expectException(new Callable<Object>()
+        {
+            public Object call()
+            {
+                copy.seek(copy.length() + 1);
+                return null;
+            }
+        }, IllegalArgumentException.class);
+
+        copy.seek(0);
+        copy.skipBytes(5);
+
+        assertEquals(copy.bytesRemaining(), 15);
+        assertEquals(copy.getFilePointer(), 5);
+        assertTrue(!copy.isEOF());
+
+        copy.seek(0);
+        ByteBuffer contents = copy.readBytes((int) copy.length());
+
+        assertEquals(contents.limit(), copy.length());
+        assertTrue(ByteBufferUtil.compare(contents, data) == 0);
+
+        copy.seek(0);
+
+        int count = 0;
+        while (!copy.isEOF())
+        {
+            assertEquals((byte) copy.read(), 'c');
+            count++;
+        }
+
+        assertEquals(count, copy.length());
+
+        copy.seek(0);
+        byte[] content = new byte[10];
+        copy.read(content);
+
+        assertEquals(new String(content), "cccccccccc");
+
+        file.close();
+        copy.close();
+    }
+
+    @Test (expected=IllegalArgumentException.class)
+    public void testSetNegativeLength() throws IOException, IllegalArgumentException
+    {
+        File tmpFile = File.createTempFile("set_negative_length", "bin");
+        try (SequentialWriter file = SequentialWriter.open(tmpFile))
+        {
+            file.truncate(-8L);
+        }
+    }
+
+    private SequentialWriter createTempFile(String name) throws IOException
+    {
+        File tempFile = File.createTempFile(name, null);
+        tempFile.deleteOnExit();
+
+        return SequentialWriter.open(tempFile);
+    }
+
+    private File writeTemporaryFile(byte[] data) throws IOException
+    {
+        File f = File.createTempFile("BRAFTestFile", null);
+        f.deleteOnExit();
+        FileOutputStream fout = new FileOutputStream(f);
+        fout.write(data);
+        fout.getFD().sync();
+        fout.close();
+        return f;
+    }
+
+    private byte[] generateByteArray(int length)
+    {
+        byte[] arr = new byte[length];
+
+        for (int i = 0; i < length; i++)
+            arr[i] = 'a';
+
+        return arr;
+    }
+}

--- a/test/unit/org/apache/cassandra/streaming/StreamingTransferTest.java
+++ b/test/unit/org/apache/cassandra/streaming/StreamingTransferTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,16 +43,12 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.KSMetaData;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.RangeDeletionTest;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.*;
-import org.apache.cassandra.db.atoms.AtomIterator;
-import org.apache.cassandra.db.atoms.Row;
-import org.apache.cassandra.db.atoms.RowIterator;
-import org.apache.cassandra.db.atoms.RowIteratorFromAtomIterator;
+import org.apache.cassandra.db.atoms.*;
 import org.apache.cassandra.db.context.CounterContext;
-import org.apache.cassandra.db.marshal.BytesType;
-import org.apache.cassandra.db.marshal.CounterColumnType;
-import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.*;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.dht.IPartitioner;
@@ -98,8 +95,9 @@ public class StreamingTransferTest
                         .addPartitionKey("key", BytesType.instance)
                         .build(),
                 CFMetaData.Builder.create(KEYSPACE1, CF_STANDARDINT)
-                        .withColumnNameComparator(IntegerType.instance)
-                        .addPartitionKey("key", BytesType.instance)
+                        .addPartitionKey("key", AsciiType.instance)
+                        .addClusteringColumn("cols", Int32Type.instance)
+                        .addRegularColumn("val", BytesType.instance)
                         .build(),
                 SchemaLoader.indexCFMD(KEYSPACE1, CF_INDEX, true));
         SchemaLoader.createKeyspace(KEYSPACE2,
@@ -214,8 +212,8 @@ public class StreamingTransferTest
 
             assert readCommand.executeLocally(cfs).hasNext();
             RowIterator row = new RowIteratorFromAtomIterator(iterator.next());
-            assert row.partitionKey().equals(ByteBufferUtil.bytes(key));
-            assert Util.getRegularCell(cfs.metadata, row.next(), col) != null;
+            assert ByteBufferUtil.compareUnsigned(row.partitionKey().getKey(), ByteBufferUtil.bytes(key)) == 0;
+            assert ByteBufferUtil.compareUnsigned(row.next().clustering().get(0), ByteBufferUtil.bytes(col)) == 0;
         }
 
         // and no extra partitions
@@ -290,7 +288,7 @@ public class StreamingTransferTest
             long val = key.hashCode();
 
             // test we can search:
-            UntypedResultSet result = QueryProcessor.executeInternal(String.format("SELECT * FROM \"%s\".\"%s\" WHERE birthdate = %l",
+            UntypedResultSet result = QueryProcessor.executeInternal(String.format("SELECT * FROM \"%s\".\"%s\" WHERE birthdate = %d",
                     cfs.metadata.ksName, cfs.metadata.cfName, val));
             assertEquals(1, result.size());
 
@@ -301,24 +299,44 @@ public class StreamingTransferTest
     /**
      * Test to make sure RangeTombstones at column index boundary transferred correctly.
      */
-    /*@Test
+    @Test
     public void testTransferRangeTombstones() throws Exception
     {
         String ks = KEYSPACE1;
         String cfname = "StandardInteger1";
         Keyspace keyspace = Keyspace.open(ks);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(cfname);
+        ClusteringComparator comparator = cfs.getComparator();
 
         String key = "key1";
-        Mutation rm = new Mutation(ks, ByteBufferUtil.bytes(key));
+
+
+        RowUpdateBuilder updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros(), key);
+
         // add columns of size slightly less than column_index_size to force insert column index
-        rm.add(cfname, cellname(1), ByteBuffer.wrap(new byte[DatabaseDescriptor.getColumnIndexSize() - 64]), 2);
-        rm.add(cfname, cellname(6), ByteBuffer.wrap(new byte[DatabaseDescriptor.getColumnIndexSize()]), 2);
-        ColumnFamily cf = rm.addOrGet(cfname);
+        updates.clustering(1)
+                .add("val", ByteBuffer.wrap(new byte[DatabaseDescriptor.getColumnIndexSize() - 64]))
+                .build()
+                .apply();
+
+        updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros(), key);
+        updates.clustering(6)
+                .add("val", ByteBuffer.wrap(new byte[DatabaseDescriptor.getColumnIndexSize()]))
+                .build()
+                .apply();
+
         // add RangeTombstones
-        cf.delete(new DeletionInfo(cellname(2), cellname(3), cf.getComparator(), 1, (int) (System.currentTimeMillis() / 1000)));
-        cf.delete(new DeletionInfo(cellname(5), cellname(7), cf.getComparator(), 1, (int) (System.currentTimeMillis() / 1000)));
-        rm.applyUnsafe();
+        //updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros() + 1 , key);
+        //updates.addRangeTombstone(Slice.make(comparator, comparator.make(2), comparator.make(4)))
+        //        .build()
+        //        .apply();
+
+
+        updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros() + 1, key);
+        updates.addRangeTombstone(Slice.make(comparator, comparator.make(5), comparator.make(7)))
+                .build()
+                .apply();
+
         cfs.forceBlockingFlush();
 
         SSTableReader sstable = cfs.getSSTables().iterator().next();
@@ -329,9 +347,25 @@ public class StreamingTransferTest
         assertEquals(1, cfs.getSSTables().size());
 
         PartitionIterator rows = Util.getRangeSlice(cfs);
-        Assert.assertTrue(rows.hasNext());
-        Assert.assertFalse(!rows.hasNext());
-    }*/
+        RowIterator it = new RowIteratorFromAtomIterator(rows.next());
+
+        Assert.assertTrue(!rows.hasNext());
+        Row r = it.next();
+        System.err.println(r.toString(cfs.metadata, true));
+
+        Assert.assertFalse(r.isEmpty());
+
+        Assert.assertTrue(1 == Int32Type.instance.compose(r.clustering().get(0)));
+
+        boolean failed = false;
+        while (it.hasNext())
+        {
+            failed = true;
+            System.err.println(it.next().toString(cfs.metadata, true));
+        }
+
+        Assert.assertFalse(failed);
+    }
 
     @Test
     public void testTransferTableViaRanges() throws Exception
@@ -345,58 +379,7 @@ public class StreamingTransferTest
         doTransferTable(true);
     }
 
-    /*@Test
-    public void testTransferTableCounter() throws Exception
-    {
-        final Keyspace keyspace = Keyspace.open(KEYSPACE1);
-        final ColumnFamilyStore cfs = keyspace.getColumnFamilyStore("Counter1");
-        final CounterContext cc = new CounterContext();
-
-        final Map<String, ColumnFamily> cleanedEntries = new HashMap<>();
-
-        List<String> keys = createAndTransfer(cfs, new Mutator()
-        {
-            // Creates a new SSTable per key: all will be merged before streaming.
-            public void mutate(String key, String col, long timestamp) throws Exception
-            {
-                Map<String, ColumnFamily> entries = new HashMap<>();
-                ColumnFamily cf = ArrayBackedSortedColumns.factory.create(cfs.metadata);
-                ColumnFamily cfCleaned = ArrayBackedSortedColumns.factory.create(cfs.metadata);
-                CounterContext.ContextState state = CounterContext.ContextState.allocate(0, 1, 3);
-                state.writeLocal(CounterId.fromInt(2), 9L, 3L);
-                state.writeRemote(CounterId.fromInt(4), 4L, 2L);
-                state.writeRemote(CounterId.fromInt(6), 3L, 3L);
-                state.writeRemote(CounterId.fromInt(8), 2L, 4L);
-                cf.addColumn(new BufferCounterCell(cellname(col), state.context, timestamp));
-                cfCleaned.addColumn(new BufferCounterCell(cellname(col), cc.clearAllLocal(state.context), timestamp));
-
-                entries.put(key, cf);
-                cleanedEntries.put(key, cfCleaned);
-                cfs.addSSTable(SSTableUtils.prepare()
-                    .ks(keyspace.getName())
-                    .cf(cfs.name)
-                    .generation(0)
-                    .write(entries));
-            }
-        }, true);
-
-        // filter pre-cleaned entries locally, and ensure that the end result is equal
-        cleanedEntries.keySet().retainAll(keys);
-        SSTableReader cleaned = SSTableUtils.prepare()
-            .ks(keyspace.getName())
-            .cf(cfs.name)
-            .generation(0)
-            .write(cleanedEntries);
-        SSTableReader streamed = cfs.getSSTables().iterator().next();
-        SSTableUtils.assertContentEquals(cleaned, streamed);
-
-        // Retransfer the file, making sure it is now idempotent (see CASSANDRA-3481)
-        cfs.clearUnsafe();
-        transferSSTables(streamed);
-        SSTableReader restreamed = cfs.getSSTables().iterator().next();
-        SSTableUtils.assertContentEquals(streamed, restreamed);
-    }
-
+    /*
     @Test
     public void testTransferTableMultiple() throws Exception
     {

--- a/test/unit/org/apache/cassandra/streaming/StreamingTransferTest.java
+++ b/test/unit/org/apache/cassandra/streaming/StreamingTransferTest.java
@@ -1,0 +1,532 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.streaming;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import junit.framework.Assert;
+import org.apache.cassandra.OrderedJUnit4ClassRunner;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.ColumnDefinition;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.KSMetaData;
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.atoms.AtomIterator;
+import org.apache.cassandra.db.atoms.Row;
+import org.apache.cassandra.db.atoms.RowIterator;
+import org.apache.cassandra.db.atoms.RowIteratorFromAtomIterator;
+import org.apache.cassandra.db.context.CounterContext;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.CounterColumnType;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.locator.SimpleStrategy;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.thrift.IndexExpression;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.CounterId;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.concurrent.Refs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(OrderedJUnit4ClassRunner.class)
+public class StreamingTransferTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(StreamingTransferTest.class);
+
+    public static final InetAddress LOCAL = FBUtilities.getBroadcastAddress();
+    public static final String KEYSPACE1 = "StreamingTransferTest1";
+    public static final String CF_STANDARD = "Standard1";
+    public static final String CF_COUNTER = "Counter1";
+    public static final String CF_STANDARDINT = "StandardInteger1";
+    public static final String CF_INDEX = "Indexed1";
+    public static final String KEYSPACE_CACHEKEY = "KeyStreamingTransferTestSpace";
+    public static final String CF_STANDARD2 = "Standard2";
+    public static final String CF_STANDARD3 = "Standard3";
+    public static final String KEYSPACE2 = "StreamingTransferTest2";
+
+    @BeforeClass
+    public static void defineSchema() throws Exception
+    {
+        SchemaLoader.prepareServer();
+        StorageService.instance.initServer();
+        SchemaLoader.createKeyspace(KEYSPACE1,
+                SimpleStrategy.class,
+                KSMetaData.optsWithRF(1),
+                SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD),
+                CFMetaData.Builder.create(KEYSPACE1, CF_COUNTER, false, false, true)
+                        .addPartitionKey("key", BytesType.instance)
+                        .build(),
+                CFMetaData.Builder.create(KEYSPACE1, CF_STANDARDINT)
+                        .withColumnNameComparator(IntegerType.instance)
+                        .addPartitionKey("key", BytesType.instance)
+                        .build(),
+                SchemaLoader.indexCFMD(KEYSPACE1, CF_INDEX, true));
+        SchemaLoader.createKeyspace(KEYSPACE2,
+                SimpleStrategy.class,
+                KSMetaData.optsWithRF(1));
+        SchemaLoader.createKeyspace(KEYSPACE_CACHEKEY,
+                SimpleStrategy.class,
+                KSMetaData.optsWithRF(1),
+                SchemaLoader.standardCFMD(KEYSPACE_CACHEKEY, CF_STANDARD),
+                SchemaLoader.standardCFMD(KEYSPACE_CACHEKEY, CF_STANDARD2),
+                SchemaLoader.standardCFMD(KEYSPACE_CACHEKEY, CF_STANDARD3));
+    }
+
+    /**
+     * Test if empty {@link StreamPlan} returns success with empty result.
+     */
+    @Test
+    public void testEmptyStreamPlan() throws Exception
+    {
+        StreamResultFuture futureResult = new StreamPlan("StreamingTransferTest").execute();
+        final UUID planId = futureResult.planId;
+        Futures.addCallback(futureResult, new FutureCallback<StreamState>()
+        {
+            public void onSuccess(StreamState result)
+            {
+                assert planId.equals(result.planId);
+                assert result.description.equals("StreamingTransferTest");
+                assert result.sessions.isEmpty();
+            }
+
+            public void onFailure(Throwable t)
+            {
+                fail();
+            }
+        });
+        // should be complete immediately
+        futureResult.get(100, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testRequestEmpty() throws Exception
+    {
+        // requesting empty data should succeed
+        IPartitioner p = StorageService.getPartitioner();
+        List<Range<Token>> ranges = new ArrayList<>();
+        ranges.add(new Range<>(p.getMinimumToken(), p.getToken(ByteBufferUtil.bytes("key1"))));
+        ranges.add(new Range<>(p.getToken(ByteBufferUtil.bytes("key2")), p.getMinimumToken()));
+
+        StreamResultFuture futureResult = new StreamPlan("StreamingTransferTest")
+                                                  .requestRanges(LOCAL, LOCAL, KEYSPACE2, ranges)
+                                                  .execute();
+
+        UUID planId = futureResult.planId;
+        StreamState result = futureResult.get();
+        assert planId.equals(result.planId);
+        assert result.description.equals("StreamingTransferTest");
+
+        // we should have completed session with empty transfer
+        assert result.sessions.size() == 1;
+        SessionInfo session = Iterables.get(result.sessions, 0);
+        assert session.peer.equals(LOCAL);
+        assert session.getTotalFilesReceived() == 0;
+        assert session.getTotalFilesSent() == 0;
+        assert session.getTotalSizeReceived() == 0;
+        assert session.getTotalSizeSent() == 0;
+    }
+
+    /**
+     * Create and transfer a single sstable, and return the keys that should have been transferred.
+     * The Mutator must create the given column, but it may also create any other columns it pleases.
+     */
+    private List<String> createAndTransfer(ColumnFamilyStore cfs, Mutator mutator, boolean transferSSTables) throws Exception
+    {
+        // write a temporary SSTable, and unregister it
+        logger.debug("Mutating {}", cfs.name);
+        long timestamp = 1234;
+        for (int i = 1; i <= 3; i++)
+            mutator.mutate("key" + i, "col" + i, timestamp);
+        cfs.forceBlockingFlush();
+        Util.compactAll(cfs, Integer.MAX_VALUE).get();
+        assertEquals(1, cfs.getSSTables().size());
+
+        // transfer the first and last key
+        logger.debug("Transferring {}", cfs.name);
+        int[] offs;
+        if (transferSSTables)
+        {
+            SSTableReader sstable = cfs.getSSTables().iterator().next();
+            cfs.clearUnsafe();
+            transferSSTables(sstable);
+            offs = new int[]{1, 3};
+        }
+        else
+        {
+            long beforeStreaming = System.currentTimeMillis();
+            transferRanges(cfs);
+            cfs.discardSSTables(beforeStreaming);
+            offs = new int[]{2, 3};
+        }
+
+        // confirm that a single SSTable was transferred and registered
+        assertEquals(1, cfs.getSSTables().size());
+
+        // and that the index and filter were properly recovered
+        PartitionIterator iterator = Util.getRangeSlice(cfs);
+        for (int i = 0; i < offs.length; i++)
+        {
+            String key = "key" + offs[i];
+            String col = "col" + offs[i];
+
+            SinglePartitionReadCommand readCommand = SinglePartitionSliceCommand.create(cfs.metadata, FBUtilities.nowInSeconds(), Util.dk(key), Slices.ALL);
+
+            assert readCommand.executeLocally(cfs).hasNext();
+            RowIterator row = new RowIteratorFromAtomIterator(iterator.next());
+            assert row.partitionKey().equals(ByteBufferUtil.bytes(key));
+            assert Util.getRegularCell(cfs.metadata, row.next(), col) != null;
+        }
+
+        // and no extra partitions
+        assert !iterator.hasNext();
+
+        // and that the max timestamp for the file was rediscovered
+        assertEquals(timestamp, cfs.getSSTables().iterator().next().getMaxTimestamp());
+
+        List<String> keys = new ArrayList<>();
+        for (int off : offs)
+            keys.add("key" + off);
+
+        logger.debug("... everything looks good for {}", cfs.name);
+        return keys;
+    }
+
+    private void transferSSTables(SSTableReader sstable) throws Exception
+    {
+        IPartitioner p = StorageService.getPartitioner();
+        List<Range<Token>> ranges = new ArrayList<>();
+        ranges.add(new Range<>(p.getMinimumToken(), p.getToken(ByteBufferUtil.bytes("key1"))));
+        ranges.add(new Range<>(p.getToken(ByteBufferUtil.bytes("key2")), p.getMinimumToken()));
+        transfer(sstable, ranges);
+    }
+
+    private void transferRanges(ColumnFamilyStore cfs) throws Exception
+    {
+        IPartitioner p = StorageService.getPartitioner();
+        List<Range<Token>> ranges = new ArrayList<>();
+        // wrapped range
+        ranges.add(new Range<Token>(p.getToken(ByteBufferUtil.bytes("key1")), p.getToken(ByteBufferUtil.bytes("key0"))));
+        new StreamPlan("StreamingTransferTest").transferRanges(LOCAL, cfs.keyspace.getName(), ranges, cfs.getColumnFamilyName()).execute().get();
+    }
+
+    private void transfer(SSTableReader sstable, List<Range<Token>> ranges) throws Exception
+    {
+        new StreamPlan("StreamingTransferTest").transferFiles(LOCAL, makeStreamingDetails(ranges, Refs.tryRef(Arrays.asList(sstable)))).execute().get();
+    }
+
+    private Collection<StreamSession.SSTableStreamingSections> makeStreamingDetails(List<Range<Token>> ranges, Refs<SSTableReader> sstables)
+    {
+        ArrayList<StreamSession.SSTableStreamingSections> details = new ArrayList<>();
+        for (SSTableReader sstable : sstables)
+        {
+            details.add(new StreamSession.SSTableStreamingSections(sstable, sstables.get(sstable),
+                                                                   sstable.getPositionsForRanges(ranges),
+                                                                   sstable.estimatedKeysForRanges(ranges), sstable.getSSTableMetadata().repairedAt));
+        }
+        return details;
+    }
+
+    private void doTransferTable(boolean transferSSTables) throws Exception
+    {
+        final Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        final ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_INDEX);
+
+        List<String> keys = createAndTransfer(cfs, new Mutator()
+        {
+            public void mutate(String key, String col, long timestamp) throws Exception
+            {
+                long val = key.hashCode();
+
+                RowUpdateBuilder builder = new RowUpdateBuilder(cfs.metadata, timestamp, key);
+                builder.clustering(col).add("birthdate", ByteBufferUtil.bytes(val));
+                builder.build().applyUnsafe();
+            }
+        }, transferSSTables);
+
+        // confirm that the secondary index was recovered
+        for (String key : keys)
+        {
+            long val = key.hashCode();
+
+            // test we can search:
+            UntypedResultSet result = QueryProcessor.executeInternal(String.format("SELECT * FROM \"%s\".\"%s\" WHERE birthdate = %l",
+                    cfs.metadata.ksName, cfs.metadata.cfName, val));
+            assertEquals(1, result.size());
+
+            assert result.iterator().next().getBytes("key").equals(ByteBufferUtil.bytes(key));
+        }
+    }
+
+    /**
+     * Test to make sure RangeTombstones at column index boundary transferred correctly.
+     */
+    /*@Test
+    public void testTransferRangeTombstones() throws Exception
+    {
+        String ks = KEYSPACE1;
+        String cfname = "StandardInteger1";
+        Keyspace keyspace = Keyspace.open(ks);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(cfname);
+
+        String key = "key1";
+        Mutation rm = new Mutation(ks, ByteBufferUtil.bytes(key));
+        // add columns of size slightly less than column_index_size to force insert column index
+        rm.add(cfname, cellname(1), ByteBuffer.wrap(new byte[DatabaseDescriptor.getColumnIndexSize() - 64]), 2);
+        rm.add(cfname, cellname(6), ByteBuffer.wrap(new byte[DatabaseDescriptor.getColumnIndexSize()]), 2);
+        ColumnFamily cf = rm.addOrGet(cfname);
+        // add RangeTombstones
+        cf.delete(new DeletionInfo(cellname(2), cellname(3), cf.getComparator(), 1, (int) (System.currentTimeMillis() / 1000)));
+        cf.delete(new DeletionInfo(cellname(5), cellname(7), cf.getComparator(), 1, (int) (System.currentTimeMillis() / 1000)));
+        rm.applyUnsafe();
+        cfs.forceBlockingFlush();
+
+        SSTableReader sstable = cfs.getSSTables().iterator().next();
+        cfs.clearUnsafe();
+        transferSSTables(sstable);
+
+        // confirm that a single SSTable was transferred and registered
+        assertEquals(1, cfs.getSSTables().size());
+
+        PartitionIterator rows = Util.getRangeSlice(cfs);
+        Assert.assertTrue(rows.hasNext());
+        Assert.assertFalse(!rows.hasNext());
+    }*/
+
+    @Test
+    public void testTransferTableViaRanges() throws Exception
+    {
+        doTransferTable(false);
+    }
+
+    @Test
+    public void testTransferTableViaSSTables() throws Exception
+    {
+        doTransferTable(true);
+    }
+
+    /*@Test
+    public void testTransferTableCounter() throws Exception
+    {
+        final Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        final ColumnFamilyStore cfs = keyspace.getColumnFamilyStore("Counter1");
+        final CounterContext cc = new CounterContext();
+
+        final Map<String, ColumnFamily> cleanedEntries = new HashMap<>();
+
+        List<String> keys = createAndTransfer(cfs, new Mutator()
+        {
+            // Creates a new SSTable per key: all will be merged before streaming.
+            public void mutate(String key, String col, long timestamp) throws Exception
+            {
+                Map<String, ColumnFamily> entries = new HashMap<>();
+                ColumnFamily cf = ArrayBackedSortedColumns.factory.create(cfs.metadata);
+                ColumnFamily cfCleaned = ArrayBackedSortedColumns.factory.create(cfs.metadata);
+                CounterContext.ContextState state = CounterContext.ContextState.allocate(0, 1, 3);
+                state.writeLocal(CounterId.fromInt(2), 9L, 3L);
+                state.writeRemote(CounterId.fromInt(4), 4L, 2L);
+                state.writeRemote(CounterId.fromInt(6), 3L, 3L);
+                state.writeRemote(CounterId.fromInt(8), 2L, 4L);
+                cf.addColumn(new BufferCounterCell(cellname(col), state.context, timestamp));
+                cfCleaned.addColumn(new BufferCounterCell(cellname(col), cc.clearAllLocal(state.context), timestamp));
+
+                entries.put(key, cf);
+                cleanedEntries.put(key, cfCleaned);
+                cfs.addSSTable(SSTableUtils.prepare()
+                    .ks(keyspace.getName())
+                    .cf(cfs.name)
+                    .generation(0)
+                    .write(entries));
+            }
+        }, true);
+
+        // filter pre-cleaned entries locally, and ensure that the end result is equal
+        cleanedEntries.keySet().retainAll(keys);
+        SSTableReader cleaned = SSTableUtils.prepare()
+            .ks(keyspace.getName())
+            .cf(cfs.name)
+            .generation(0)
+            .write(cleanedEntries);
+        SSTableReader streamed = cfs.getSSTables().iterator().next();
+        SSTableUtils.assertContentEquals(cleaned, streamed);
+
+        // Retransfer the file, making sure it is now idempotent (see CASSANDRA-3481)
+        cfs.clearUnsafe();
+        transferSSTables(streamed);
+        SSTableReader restreamed = cfs.getSSTables().iterator().next();
+        SSTableUtils.assertContentEquals(streamed, restreamed);
+    }
+
+    @Test
+    public void testTransferTableMultiple() throws Exception
+    {
+        // write temporary SSTables, but don't register them
+        Set<String> content = new HashSet<>();
+        content.add("test");
+        content.add("test2");
+        content.add("test3");
+        SSTableReader sstable = new SSTableUtils(KEYSPACE1, CF_STANDARD).prepare().write(content);
+        String keyspaceName = sstable.getKeyspaceName();
+        String cfname = sstable.getColumnFamilyName();
+
+        content = new HashSet<>();
+        content.add("transfer1");
+        content.add("transfer2");
+        content.add("transfer3");
+        SSTableReader sstable2 = SSTableUtils.prepare().write(content);
+
+        // transfer the first and last key
+        IPartitioner p = StorageService.getPartitioner();
+        List<Range<Token>> ranges = new ArrayList<>();
+        ranges.add(new Range<>(p.getMinimumToken(), p.getToken(ByteBufferUtil.bytes("test"))));
+        ranges.add(new Range<>(p.getToken(ByteBufferUtil.bytes("transfer2")), p.getMinimumToken()));
+        // Acquiring references, transferSSTables needs it
+        Refs<SSTableReader> refs = Refs.tryRef(Arrays.asList(sstable, sstable2));
+        assert refs != null;
+        new StreamPlan("StreamingTransferTest").transferFiles(LOCAL, makeStreamingDetails(ranges, refs)).execute().get();
+
+        // confirm that the sstables were transferred and registered and that 2 keys arrived
+        ColumnFamilyStore cfstore = Keyspace.open(keyspaceName).getColumnFamilyStore(cfname);
+        List<Row> rows = Util.getRangeSlice(cfstore);
+        assertEquals(2, rows.size());
+        assert rows.get(0).key.getKey().equals(ByteBufferUtil.bytes("test"));
+        assert rows.get(1).key.getKey().equals(ByteBufferUtil.bytes("transfer3"));
+        assert rows.get(0).cf.getColumnCount() == 1;
+        assert rows.get(1).cf.getColumnCount() == 1;
+
+        // these keys fall outside of the ranges and should not be transferred
+        assert cfstore.getColumnFamily(QueryFilter.getIdentityFilter(Util.dk("transfer1"), "Standard1", System.currentTimeMillis())) == null;
+        assert cfstore.getColumnFamily(QueryFilter.getIdentityFilter(Util.dk("transfer2"), "Standard1", System.currentTimeMillis())) == null;
+        assert cfstore.getColumnFamily(QueryFilter.getIdentityFilter(Util.dk("test2"), "Standard1", System.currentTimeMillis())) == null;
+        assert cfstore.getColumnFamily(QueryFilter.getIdentityFilter(Util.dk("test3"), "Standard1", System.currentTimeMillis())) == null;
+    }
+
+    @Test
+    public void testTransferOfMultipleColumnFamilies() throws Exception
+    {
+        String keyspace = KEYSPACE_CACHEKEY;
+        IPartitioner p = StorageService.getPartitioner();
+        String[] columnFamilies = new String[] { "Standard1", "Standard2", "Standard3" };
+        List<SSTableReader> ssTableReaders = new ArrayList<>();
+
+        NavigableMap<DecoratedKey,String> keys = new TreeMap<>();
+        for (String cf : columnFamilies)
+        {
+            Set<String> content = new HashSet<>();
+            content.add("data-" + cf + "-1");
+            content.add("data-" + cf + "-2");
+            content.add("data-" + cf + "-3");
+            SSTableUtils.Context context = SSTableUtils.prepare().ks(keyspace).cf(cf);
+            ssTableReaders.add(context.write(content));
+
+            // collect dks for each string key
+            for (String str : content)
+                keys.put(Util.dk(str), cf);
+        }
+
+        // transfer the first and last keys
+        Map.Entry<DecoratedKey,String> first = keys.firstEntry();
+        Map.Entry<DecoratedKey,String> last = keys.lastEntry();
+        Map.Entry<DecoratedKey,String> secondtolast = keys.lowerEntry(last.getKey());
+        List<Range<Token>> ranges = new ArrayList<>();
+        ranges.add(new Range<>(p.getMinimumToken(), first.getKey().getToken()));
+        // the left hand side of the range is exclusive, so we transfer from the second-to-last token
+        ranges.add(new Range<>(secondtolast.getKey().getToken(), p.getMinimumToken()));
+
+        // Acquiring references, transferSSTables needs it
+        Refs<SSTableReader> refs = Refs.tryRef(ssTableReaders);
+        if (refs == null)
+            throw new AssertionError();
+
+        new StreamPlan("StreamingTransferTest").transferFiles(LOCAL, makeStreamingDetails(ranges, refs)).execute().get();
+
+        // check that only two keys were transferred
+        for (Map.Entry<DecoratedKey,String> entry : Arrays.asList(first, last))
+        {
+            ColumnFamilyStore store = Keyspace.open(keyspace).getColumnFamilyStore(entry.getValue());
+            List<Row> rows = Util.getRangeSlice(store);
+            assertEquals(rows.toString(), 1, rows.size());
+            assertEquals(entry.getKey(), rows.get(0).key);
+        }
+    }
+
+    @Test
+    public void testRandomSSTableTransfer() throws Exception
+    {
+        final Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        final ColumnFamilyStore cfs = keyspace.getColumnFamilyStore("Standard1");
+        Mutator mutator = new Mutator()
+        {
+            public void mutate(String key, String colName, long timestamp) throws Exception
+            {
+                ColumnFamily cf = ArrayBackedSortedColumns.factory.create(keyspace.getName(), cfs.name);
+                cf.addColumn(column(colName, "value", timestamp));
+                cf.addColumn(new BufferCell(cellname("birthdate"), ByteBufferUtil.bytes(new Date(timestamp).toString()), timestamp));
+                Mutation rm = new Mutation(KEYSPACE1, ByteBufferUtil.bytes(key), cf);
+                logger.debug("Applying row to transfer {}", rm);
+                rm.applyUnsafe();
+            }
+        };
+        // write a lot more data so the data is spread in more than 1 chunk.
+        for (int i = 1; i <= 6000; i++)
+            mutator.mutate("key" + i, "col" + i, System.currentTimeMillis());
+        cfs.forceBlockingFlush();
+        Util.compactAll(cfs, Integer.MAX_VALUE).get();
+        SSTableReader sstable = cfs.getSSTables().iterator().next();
+        cfs.clearUnsafe();
+
+        IPartitioner p = StorageService.getPartitioner();
+        List<Range<Token>> ranges = new ArrayList<>();
+        ranges.add(new Range<>(p.getToken(ByteBufferUtil.bytes("key1")), p.getToken(ByteBufferUtil.bytes("key1000"))));
+        ranges.add(new Range<>(p.getToken(ByteBufferUtil.bytes("key5")), p.getToken(ByteBufferUtil.bytes("key500"))));
+        ranges.add(new Range<>(p.getToken(ByteBufferUtil.bytes("key9")), p.getToken(ByteBufferUtil.bytes("key900"))));
+        transfer(sstable, ranges);
+        assertEquals(1, cfs.getSSTables().size());
+        assertEquals(7, Util.getRangeSlice(cfs).size());
+    }
+*/
+    public interface Mutator
+    {
+        public void mutate(String key, String col, long timestamp) throws Exception;
+    }
+}

--- a/test/unit/org/apache/cassandra/streaming/StreamingTransferTest.java
+++ b/test/unit/org/apache/cassandra/streaming/StreamingTransferTest.java
@@ -326,14 +326,26 @@ public class StreamingTransferTest
                 .apply();
 
         // add RangeTombstones
-        //updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros() + 1 , key);
-        //updates.addRangeTombstone(Slice.make(comparator, comparator.make(2), comparator.make(4)))
-        //        .build()
-        //        .apply();
+        updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros() + 1 , key);
+        updates.addRangeTombstone(Slice.make(comparator, comparator.make(2), comparator.make(4)))
+                .build()
+                .apply();
 
 
         updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros() + 1, key);
         updates.addRangeTombstone(Slice.make(comparator, comparator.make(5), comparator.make(7)))
+                .build()
+                .apply();
+
+        //Overlapping Range tombstone (start overlaps prev end)
+        updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros() + 1, key);
+        updates.addRangeTombstone(Slice.make(comparator, comparator.make(4), comparator.make(10)))
+                .build()
+                .apply();
+
+        //Overlapping Range tombstone (end overlaps prev start)
+        updates = new RowUpdateBuilder(cfs.metadata, FBUtilities.timestampMicros() + 1, key);
+        updates.addRangeTombstone(Slice.make(comparator, comparator.make(3), comparator.make(4)))
                 .build()
                 .apply();
 


### PR DESCRIPTION
The RangeTombstoneList code inverts start and end bounds without changing the kind.  This causes assertion errors.  To fix I added an invert() call to Bound and added a test.
